### PR TITLE
fix inverse of 1x1 matrix

### DIFF
--- a/METAMVGL.py
+++ b/METAMVGL.py
@@ -226,7 +226,16 @@ else:
         all_trans_uu = all_trans[binned_cnt:, binned_cnt:]
         all_trans_ul = all_trans[binned_cnt:, :binned_cnt]
         try:
-            F_u = sp.sparse.linalg.inv(sp.sparse.eye(all_trans_uu.shape[0], format='csc', dtype=np.float64) - all_trans_uu).dot(all_trans_ul).dot(F_l)
+            eye = sp.sparse.eye(all_trans_uu.shape[0], format='csc', dtype=np.float64) - all_trans_uu
+
+            # for whatever reason, inv(<1x1 sparse matrix>) returns an array
+            # instead of a matrix. No use taking the inverse anyway.
+            if eye.shape == (1, 1):
+                inv = sp.sparse.csc_matrix(sp.sparse.linalg.inv(eye))
+            else:
+                inv = sp.sparse.linalg.inv(eye)
+
+            F_u = inv.dot(all_trans_ul).dot(F_l)
             F = sp.sparse.vstack([F_l, F_u], format='csc', dtype=np.float64)
             obj1 = math.sqrt(F.T.dot(assembly_graph_L).dot(F).diagonal().sum())
             obj2 = math.sqrt(F.T.dot(PE_graph_L).dot(F).diagonal().sum())


### PR DESCRIPTION
Fixes https://github.com/ZhangZhenmiao/METAMVGL/issues/13

Thanks for the great tool.

I chased this down to when there is a single-element sparse matrix.

I noticed some weird behaviour from scipy:
```
(Pdb) my_matrix = sp.sparse.eye(all_trans_uu.shape[0], format='csc', dtype=np.float64) - all_trans_uu
(Pdb) my_matrix
<1x1 sparse matrix of type '<class 'numpy.float64'>'
        with 1 stored elements in Compressed Sparse Column format>
(Pdb) sp.sparse.linalg.inv(my_matrix)
array([1.])
```

Notice how the return value of `inv` is an array, not a sparse matrix. When fed a `2x2` (or higher-dimension) matrix, it returns a sparse matrix. I'm not sure if this is a scipy bug, I don't know scipy well enough. We could open an issue there.

Anyway, this fixes METAMVGL from erroring in that case.